### PR TITLE
Top half of kmeans-scala makefile moved to benchmarks Makefile.options

### DIFF
--- a/benchmarks/Makefile.options
+++ b/benchmarks/Makefile.options
@@ -4,7 +4,6 @@
 #2. configurations for running on miga/octavia/another system
 #3. sourcing of any paths
 
-TARGET:=./target/scala-2.11/kmeans-assembly-1.0.jar
 
 
 ifeq ($(LOCAL),1)
@@ -27,10 +26,3 @@ endif
 SPARK_SUBMIT := spark-submit $(SPARK_SUBMIT_ARGS)
 # SPARK_SUBMIT_LOCAL := spark-submit $(SPARK_SUBMIT_ARGS_LOCAL)
 
-all: $(TARGET)
-$(TARGET): ./kmeans.scala ./kmeans.sbt
-	sbt assembly
-	#sbt package
-
-clean:
-	sbt clean

--- a/benchmarks/Makefile.options
+++ b/benchmarks/Makefile.options
@@ -3,3 +3,34 @@
 #1. spark-submit parameters for logging
 #2. configurations for running on miga/octavia/another system
 #3. sourcing of any paths
+
+TARGET:=./target/scala-2.11/kmeans-assembly-1.0.jar
+
+
+ifeq ($(LOCAL),1)
+SPARK_SUBMIT_ARGS :=
+PROFILE_NAME := accumulo-rankings-local
+export LOCAL
+$(warning export local)
+else
+SPARK_SUBMIT_ARGS := --deploy-mode=cluster --master yarn --num-executors 10 --executor-memory=1g
+# SPARK_SUBMIT_ARGS_LOCAL := --master local[4]
+PROFILE_NAME := accumulo-rankings-cluster
+endif
+
+ifdef LOCAL
+# override the local environment while make is running:
+export HADOOP_CONF_DIR=""
+SPARK_SUBMIT_ARGS := --master local[$(LOCAL)]
+endif
+
+SPARK_SUBMIT := spark-submit $(SPARK_SUBMIT_ARGS)
+# SPARK_SUBMIT_LOCAL := spark-submit $(SPARK_SUBMIT_ARGS_LOCAL)
+
+all: $(TARGET)
+$(TARGET): ./kmeans.scala ./kmeans.sbt
+	sbt assembly
+	#sbt package
+
+clean:
+	sbt clean

--- a/benchmarks/kmeans/kmeans-scala/Makefile
+++ b/benchmarks/kmeans/kmeans-scala/Makefile
@@ -1,5 +1,15 @@
 include ../../Makefile.options
 
+TARGET:=./target/scala-2.11/kmeans-assembly-1.0.jar
+
+all: $(TARGET)
+$(TARGET): ./kmeans.scala ./kmeans.sbt
+	sbt assembly
+	#sbt package
+
+clean:
+	sbt clean
+
 ../../data/amazon_reviews/reviews_books_first_1000.json:
 	make -C ../../data/amazon_reviews/ all
 	ln -s ../../data/amazon_reviews/reviews_books_first_1000.json

--- a/benchmarks/kmeans/kmeans-scala/Makefile
+++ b/benchmarks/kmeans/kmeans-scala/Makefile
@@ -29,17 +29,18 @@ $(TARGET): ./kmeans.scala ./kmeans.sbt
 clean:
 	sbt clean
 
-../../data/amazon_reviews/reviews_books_first_1000.json: 
+../../data/amazon_reviews/reviews_books_first_1000.json:
 	make -C ../../data/amazon_reviews/ all
+	cp ../../data/amazon_reviews/reviews_books_first_1000.json ./
 
-run-kmeans: ../../data/amazon_reviews/reviews_books_first_1000.json $(TARGET) 
+run-kmeans: ../../data/amazon_reviews/reviews_books_first_1000.json $(TARGET)
 ifdef LOCAL
 	rm -rf myModelPath
 else
 	# Remove files that were left over from previous executions
 	hdfs dfs -rm -r -f /user/root/myModelPath/data
 	hdfs dfs -rm -r -f /user/root/myModelPath/metadata
-	hdfs dfs -put -f kmeans_data.txt /user/root/data/mllib/
+	hdfs dfs -put -f reviews_books_first_1000.json /user/root/
 endif
 	$(SPARK_SUBMIT) --class benchKmeans $(TARGET) accumulo 172.17.0.3 root accumulo
 

--- a/benchmarks/kmeans/kmeans-scala/Makefile
+++ b/benchmarks/kmeans/kmeans-scala/Makefile
@@ -1,37 +1,8 @@
-TARGET:=./target/scala-2.11/kmeans-assembly-1.0.jar
-
-
-ifeq ($(LOCAL),1)
-SPARK_SUBMIT_ARGS :=
-PROFILE_NAME := accumulo-rankings-local
-export LOCAL
-$(warning export local)
-else
-SPARK_SUBMIT_ARGS := --deploy-mode=cluster --master yarn --num-executors 10 --executor-memory=1g
-# SPARK_SUBMIT_ARGS_LOCAL := --master local[4]
-PROFILE_NAME := accumulo-rankings-cluster
-endif
-
-ifdef LOCAL
-# override the local environment while make is running:
-export HADOOP_CONF_DIR=""
-SPARK_SUBMIT_ARGS := --master local[$(LOCAL)]
-endif
-
-SPARK_SUBMIT := spark-submit $(SPARK_SUBMIT_ARGS)
-# SPARK_SUBMIT_LOCAL := spark-submit $(SPARK_SUBMIT_ARGS_LOCAL)
-
-all: $(TARGET)
-$(TARGET): ./kmeans.scala ./kmeans.sbt
-	sbt assembly
-	#sbt package
-
-clean:
-	sbt clean
+include ../../Makefile.options
 
 ../../data/amazon_reviews/reviews_books_first_1000.json:
 	make -C ../../data/amazon_reviews/ all
-	cp ../../data/amazon_reviews/reviews_books_first_1000.json ./
+	ln -s ../../data/amazon_reviews/reviews_books_first_1000.json
 
 run-kmeans: ../../data/amazon_reviews/reviews_books_first_1000.json $(TARGET)
 ifdef LOCAL

--- a/benchmarks/kmeans/kmeans-scala/kmeans.scala
+++ b/benchmarks/kmeans/kmeans-scala/kmeans.scala
@@ -11,7 +11,7 @@ object benchKmeans {
 
     // Load and parse the data
     val data       = sc.textFile("reviews_books_first_1000.json")
-    val parsedData =  data.map(s => Vectors.dense(s.split(' ').map(_.toDouble))).cache()
+    val parsedData = data.map(s => Vectors.dense(s.split(' ').map(_.toDouble))).cache()
 
     // Cluster the data into two classes using KMeans
     val numClusters   = 2

--- a/benchmarks/kmeans/kmeans-scala/kmeans.scala
+++ b/benchmarks/kmeans/kmeans-scala/kmeans.scala
@@ -10,7 +10,7 @@ object benchKmeans {
     val sc   = new SparkContext(conf)
 
     // Load and parse the data
-    val data       =  sc.textFile("kmeans_data.txt")
+    val data       = sc.textFile("../../data/amazon_reviews/reviews_books_first_1000.json")
     val parsedData =  data.map(s => Vectors.dense(s.split(' ').map(_.toDouble))).cache()
 
     // Cluster the data into two classes using KMeans

--- a/benchmarks/kmeans/kmeans-scala/kmeans.scala
+++ b/benchmarks/kmeans/kmeans-scala/kmeans.scala
@@ -10,7 +10,7 @@ object benchKmeans {
     val sc   = new SparkContext(conf)
 
     // Load and parse the data
-    val data       = sc.textFile("../../data/amazon_reviews/reviews_books_first_1000.json")
+    val data       = sc.textFile("reviews_books_first_1000.json")
     val parsedData =  data.map(s => Vectors.dense(s.split(' ').map(_.toDouble))).cache()
 
     // Cluster the data into two classes using KMeans


### PR DESCRIPTION
I moved the top half of the scala kmeans makefile to the Makefile.options file, and included the Makefile.options file from the scala kmeans Makefile and everything seems to be working.

I also changed the Makefile and scala code to use the new dataset. I needed to symlink the file so that the symlink appears in the kmeans-scala folder to make it easier to run on hdfs and locally. Essentially, it makes it so that the same path can be used when running on hdfs as running locally, which is to use the current directory. So after the file gets downloaded, it then symlinks it.

I have not yet added code to the scala file to properly process the new dataset though.
