### PR TITLE
Spark 1.6.0 does not exist on mirror.its.dal.ca

### DIFF
--- a/docker-spark/Dockerfile
+++ b/docker-spark/Dockerfile
@@ -21,10 +21,10 @@ ENV JAVA_TOOL_OPTIONS="-XX:+PreserveFramePointer -agentpath:/root/perf-map-agent
 RUN echo "export JAVA_TOOL_OPTIONS=\"-XX:+PreserveFramePointer -agentpath:/root/perf-map-agent/out/libperfmap.so\"" >> ~/.bash_profile
 
 #RUN curl http://mirror.its.dal.ca/apache/spark/spark-1.6.0/spark-1.6.0-bin-hadoop2.6.tgz | tar -xz -C /usr/local
-COPY ./build/packages/spark-1.6.0-bin-hadoop2.6.tgz /usr/local/
-RUN tar -xzf /usr/local/spark-1.6.0-bin-hadoop2.6.tgz -C /usr/local
+COPY ./build/packages/spark-1.6.1-bin-hadoop2.6.tgz /usr/local/
+RUN tar -xzf /usr/local/spark-1.6.1-bin-hadoop2.6.tgz -C /usr/local
 
-RUN cd /usr/local && ln -sf spark-1.6.0-bin-hadoop2.6 spark
+RUN cd /usr/local && ln -sf spark-1.6.1-bin-hadoop2.6 spark
 
 COPY run_container.sh /usr/local/spark/
 
@@ -59,7 +59,7 @@ RUN ln -sf /usr/local/spark /root/spark
 ENV PATH $PATH:/usr/local/hadoop/bin:/usr/local/spark/bin
 RUN echo "export PATH=\$PATH:/usr/local/hadoop/bin:/usr/local/spark/bin" >> /root/.bash_profile
 #commented out for now to test the oracle jdk
-#RUN echo "export JAVA_HOME=/usr/lib/jvm/jre" >> /root/.bash_profile 
+#RUN echo "export JAVA_HOME=/usr/lib/jvm/jre" >> /root/.bash_profile
 #RUN mkdir -p /usr/java/ && ln -sf /usr/lib/jvm/jre /usr/java/default
 ENV HADOOP_CONF_DIR /usr/local/hadoop/etc/hadoop
 

--- a/docker-spark/Makefile
+++ b/docker-spark/Makefile
@@ -11,7 +11,7 @@ include ../Makefile.options
 #so it's easy to rebuild a container without download times
 packages_dir := build/packages
 packages := java.rpm \
-	spark-1.6.0-bin-hadoop2.6.tgz
+	spark-1.6.1-bin-hadoop2.6.tgz
 packages := $(packages:%=$(packages_dir)/%)
 .PRECIOUS: $(packages)
 
@@ -23,8 +23,8 @@ $(packages_dir)/java.rpm: | $(packages_dir)
 		'http://download.oracle.com/otn-pub/java/jdk/8u77-b03/jdk-8u77-linux-x64.rpm'\
 		-H 'Cookie: oraclelicense=accept-securebackup-cookie' > $@
 
-$(packages_dir)/spark-1.6.0-bin-hadoop2.6.tgz: | $(packages_dir)
-	cd $(packages_dir) && wget http://mirror.its.dal.ca/apache/spark/spark-1.6.0/spark-1.6.0-bin-hadoop2.6.tgz
+$(packages_dir)/spark-1.6.1-bin-hadoop2.6.tgz: | $(packages_dir)
+	cd $(packages_dir) && wget http://mirror.its.dal.ca/apache/spark/spark-1.6.1/spark-1.6.1-bin-hadoop2.6.tgz
 
 build := build/image
 build: $(build)
@@ -34,7 +34,7 @@ $(build): Dockerfile $(packages)
 	touch $@
 
 cid_file := build/container_id
-$(cid_file): $(build) 
+$(cid_file): $(build)
 	docker create \
 		--volumes-from hadoop_master-$(shell whoami) \
 		--privileged=true \
@@ -57,7 +57,7 @@ clean_container:
 clean_image:
 	-docker rmi $(IMAGE_NAME) && rm $(build)
 
-shell: 
+shell:
 	docker exec -it $(CONTAINER_NAME) bash
 
 #command that runs a test against the hadoop setup - should work
@@ -73,7 +73,7 @@ test: start
 	    lib/spark-examples*.jar \
 	    10'
 
-ssh: 
+ssh:
 	ssh -o StrictHostKeyChecking=no \
 	       -o UserKnownHostsFile=/dev/null \
        	       -i build/id_rsa root@`cat build/ip`


### PR DESCRIPTION
Spark 1.6.0 appears to not exist on the above webpage anymore. I changed
these files to use 1.6.1 so that it will work. Maybe we want to address
this so that this kind of thing does not happen again?
