### PR TITLE
Make executor Memory 10GB

### DIFF
--- a/benchmarks/spark-perf/Makefile
+++ b/benchmarks/spark-perf/Makefile
@@ -9,9 +9,3 @@ generate-config-local:
 generate-config-cluster:
 	./run-script.sh config
 
-run-local: generate-config-local
-	./run-script.sh
-
-run-cluster: generate-config-cluster
-	./run-script.sh
-

--- a/benchmarks/spark-perf/README.md
+++ b/benchmarks/spark-perf/README.md
@@ -6,25 +6,13 @@
 $ make generate-config-local
 ```
 
-#### Generate a config.py file for Local Execution and Run
-
-```bash
-$ make run-local
-```
-
 #### Generate a config.py file for Cluster Execution
 
 ```bash
 $ make generate-config-cluster
 ```
 
-#### Generate a config.py file for Cluster Execution and Run
-
-```bash
-$ make run-cluster
-```
-
-#### Just Run with the current Config
+#### Run Using the Current Configuration
 
 ```bash
 $ make

--- a/benchmarks/spark-perf/run-script.sh
+++ b/benchmarks/spark-perf/run-script.sh
@@ -19,7 +19,6 @@ function default_config {
     sed -i '/SPARK_DRIVER_MEMORY = /c\SPARK_DRIVER_MEMORY = \"1g\"' $CONFIG_PATH/config.py
     sed -i '/spark\.executor\.memory/c\# JavaOptionSet(\"spark\.executor\.memory\", \[\"2g\"\]),' $CONFIG_PATH/config.py
   elif [[ "$HOSTNAME" == "octavia" ]]; then
-    echo "hi"
     sed -i '/SPARK_CLUSTER_URL = /c\SPARK_CLUSTER_URL = \"spark:\/\/octavia:7077\"' "$CONFIG_PATH"/config.py
     sed -i '/SCALE_FACTOR = /c\SCALE_FACTOR = 0.05' "$CONFIG_PATH"/config.py
     sed -i '/SPARK_DRIVER_MEMORY = /c\SPARK_DRIVER_MEMORY = \"1g\"' "$CONFIG_PATH"/config.py
@@ -47,6 +46,17 @@ if [[ "$1" == "config" ]]; then
 
   # set spark_home_dir to $SPARK_BIN
   sed -i '/SPARK_HOME_DIR = /c\SPARK_HOME_DIR = \"'"$SPARK_BIN"'\"' $CONFIG_PATH/config.py
+
+  sed -i '/RUN_SPARK_TESTS = /c\RUN_SPARK_TESTS = True' $CONFIG_PATH/config.py
+  sed -i '/RUN_PYSPARK_TESTS = /c\RUN_PYSPARK_TESTS = True' $CONFIG_PATH/config.py
+  sed -i '/RUN_STREAMING_TESTS = /c\RUN_STREAMING_TESTS = True' $CONFIG_PATH/config.py
+  sed -i '/RUN_MLLIB_TESTS = /c\RUN_MLLIB_TESTS = True' $CONFIG_PATH/config.py
+  sed -i '/RUN_PYTHON_MLLIB_TESTS = /c\RUN_PYTHON_MLLIB_TESTS = True' $CONFIG_PATH/config.py
+
+  sed -i '/PREP_SPARK_TESTS = /c\PREP_SPARK_TESTS = True' $CONFIG_PATH/config.py
+  sed -i '/PREP_PYSPARK_TESTS = /c\PREP_PYSPARK_TESTS = True' $CONFIG_PATH/config.py
+  sed -i '/PREP_STREAMING_TESTS = /c\PREP_STREAMING_TESTS = True' $CONFIG_PATH/config.py
+  sed -i '/PREP_MLLIB_TESTS = /c\PREP_MLLIB_TESTS = True' $CONFIG_PATH/config.py
 
   if [[ "$2" == "local" ]]; then
     echo "Create a config for local execution"

--- a/benchmarks/spark-perf/run-script.sh
+++ b/benchmarks/spark-perf/run-script.sh
@@ -7,7 +7,7 @@ function local_config {
   sed -i '/SPARK_CLUSTER_URL = /c\SPARK_CLUSTER_URL = \"spark:\/\/%s:7077 % socket.gethostname()\"' $CONFIG_PATH/config.py
   sed -i '/SCALE_FACTOR = /c\SCALE_FACTOR = 0.05' $CONFIG_PATH/config.py
   sed -i '/SPARK_DRIVER_MEMORY = /c\SPARK_DRIVER_MEMORY = \"512m\"' $CONFIG_PATH/config.py
-  sed -i '/spark\.executor\.memory/c\# JavaOptionSet(\"spark\.executor\.memory\", \[\"2g\"\]),' $CONFIG_PATH/config.py
+  sed -i '/spark\.executor\.memory/c\JavaOptionSet(\"spark\.executor\.memory\", \[\"10g\"\]),' $CONFIG_PATH/config.py
 }
 
 #}}}
@@ -17,17 +17,17 @@ function default_config {
     sed -i '/SPARK_CLUSTER_URL = /c\SPARK_CLUSTER_URL = \"spark:\/\/miga:7077\"' $CONFIG_PATH/config.py
     sed -i '/SCALE_FACTOR = /c\SCALE_FACTOR = 0.05' $CONFIG_PATH/config.py
     sed -i '/SPARK_DRIVER_MEMORY = /c\SPARK_DRIVER_MEMORY = \"1g\"' $CONFIG_PATH/config.py
-    sed -i '/spark\.executor\.memory/c\# JavaOptionSet(\"spark\.executor\.memory\", \[\"2g\"\]),' $CONFIG_PATH/config.py
+    sed -i '/spark\.executor\.memory/c\JavaOptionSet(\"spark\.executor\.memory\", \[\"10g\"\]),' $CONFIG_PATH/config.py
   elif [[ "$HOSTNAME" == "octavia" ]]; then
     sed -i '/SPARK_CLUSTER_URL = /c\SPARK_CLUSTER_URL = \"spark:\/\/octavia:7077\"' "$CONFIG_PATH"/config.py
     sed -i '/SCALE_FACTOR = /c\SCALE_FACTOR = 0.05' "$CONFIG_PATH"/config.py
     sed -i '/SPARK_DRIVER_MEMORY = /c\SPARK_DRIVER_MEMORY = \"1g\"' "$CONFIG_PATH"/config.py
-    sed -i '/spark\.executor\.memory/c\# JavaOptionSet(\"spark\.executor\.memory\", \[\"2g\"\]),' "$CONFIG_PATH"/config.py
+    sed -i '/spark\.executor\.memory/c\JavaOptionSet(\"spark\.executor\.memory\", \[\"10g\"\]),' "$CONFIG_PATH"/config.py
   else
     sed -i '/SPARK_CLUSTER_URL = /c\SPARK_CLUSTER_URL = \"spark:\/\/localhost:7077\"' $CONFIG_PATH/config.py
     sed -i '/SCALE_FACTOR = /c\SCALE_FACTOR = 0.05' $CONFIG_PATH/config.py
     sed -i '/SPARK_DRIVER_MEMORY = /c\SPARK_DRIVER_MEMORY = \"1g\"' $CONFIG_PATH/config.py
-    sed -i '/spark\.executor\.memory/c\# JavaOptionSet(\"spark\.executor\.memory\", \[\"2g\"\]),' $CONFIG_PATH/config.py
+    sed -i '/spark\.executor\.memory/c\JavaOptionSet(\"spark\.executor\.memory\", \[\"10g\"\]),' $CONFIG_PATH/config.py
   fi
 }
 #}}}

--- a/docker-hadoop/Makefile
+++ b/docker-hadoop/Makefile
@@ -53,7 +53,7 @@ $(cid_file): $(build) | $(HADOOP_DATA_DIR)
 	echo $(CONTAINER_NAME) > $@
 
 #how to run:
-start: $(cid_file) 
+start: $(cid_file)
 	docker start $(CONTAINER_NAME)
 	#docker inspect --format '{{ .Config.Hostname }}' `cat build/container_id` > $(host_file)
 	#below only works with bridge networking


### PR DESCRIPTION
#### benchmarks/spark-perf/Makefile and README Changes

Removed Some target dependencies for run-local and run-cluster targets. I have a few custom modifications to the config file specific to my runs that I did not want to accidentally overwrite by running these targets for the makefile. If you want to generate a new config file you can run the generate targets in the makefile separate from running. The readme just reflects these changes.
#### benchmarks/spark-perf/run-script.sh Changes

The script has been changed to add some more configs to the config file of spark-perf. Now it will make the executor memory equal 10GB, and it enables all tests.
#### docker-hadoop/Makefile Changes

Just a removal of a trailing space character
