### PR TITLE
get-log script

### DIFF
--- a/benchmarks/spark-perf/.gitignore
+++ b/benchmarks/spark-perf/.gitignore
@@ -1,0 +1,3 @@
+.source.sh
+.timestamp_file
+logs

--- a/benchmarks/spark-perf/Makefile
+++ b/benchmarks/spark-perf/Makefile
@@ -1,7 +1,40 @@
 #!/bin/bash
 
-run:
-	./run-script.sh
+all:
+	@# If their is less than 2GB (2000000KB) of disk space left, don't run the
+	@# script
+	@#
+	@# If both files do not exist then start up the script. Create the two files,
+	@# populate it with the first execution of get-logs.sh, run the benchmarks
+	@# then after the tests, run get-logs again, and remove the files
+	@#
+	@# If both files exist, run get-logs.sh
+	@#
+	@# Otherwise, Return an error
+	@ if [ ! -f .source.sh -a ! -f .timestamp_file ] ; \
+	then \
+		available_disk_kb=$$(df -k . | cut -d' ' -f4) ; \
+		if [ "$$available_disk_kb" -lt "2000000" ]; \
+		then \
+			echo "Not Enough Disk Space to Execute Spark-Perf!" ; \
+			exit 1 ; \
+		fi ; \
+		touch .timestamp_file ; \
+		touch .source.sh ; \
+		./get-logs.sh --setup_exec_time ; \
+		./run-script.sh ; \
+		./get-logs.sh --last_exec ; \
+		rm -rf .timestamp_file ; \
+		rm -rf .source.sh ; \
+		rm -rf .get-log-inprogress \
+	elif [ -f .source.sh -a -f .timestamp_file ] ; \
+	then \
+		echo "Fetching the Logs" ; \
+		./get-logs.sh ; \
+	else \
+		echo "Something went wrong!" ; \
+		echo "One of the files: .source.sh or .timestamp_file are missing" ; \
+	fi;
 
 generate-config-local:
 	./run-script.sh config local
@@ -9,3 +42,7 @@ generate-config-local:
 generate-config-cluster:
 	./run-script.sh config
 
+clean:
+	rm -rf .timestamp_file
+	rm -rf .source.sh
+	rm -rf .get-log-inprogress

--- a/benchmarks/spark-perf/README.md
+++ b/benchmarks/spark-perf/README.md
@@ -12,18 +12,18 @@ $ make generate-config-local
 $ make generate-config-cluster
 ```
 
-#### Run Using the Current Configuration
+#### Run Using the Current Configuration or Fetch Logs
+
+The following command is used to both execute the spark-perf benchmarks and
+fetch the logs.
+
+If neither the .source.sh file or .timestamp_file exist then the benchmarks will
+run. If both files exist then this command fetches the logs. If only one of them
+exists then it returns an eror.
 
 ```bash
 $ make
 ```
-
-Or:
-
-```bash
-$ make run
-```
-
 
 ## SSH Setup
 

--- a/benchmarks/spark-perf/get-logs.sh
+++ b/benchmarks/spark-perf/get-logs.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+# TODO:
+# Copy HDFS files to /mnt/scratch/spark_event_logs_<exec date and time>
+
+
+mkdir -p "$SPARK_PERF_LOGS"
+cd "$SPARK_PERF_LOGS"/../ || exit
+
+result_log_files=( $(find "$PWD"/spark-perf/results/ -maxdepth 1 -type d -newer ".timestamp_file") )
+
+cd "$SPARK_PERF_LOGS"
+
+if [ ! -f ../.timestamp_file  ]; then
+  echo ".timestamp_file not found. This is required in order to go further."
+  exit 1
+fi
+
+# Check if source.sh exists. It has to exist in order to continue.
+if [ ! -f ../.source.sh  ]; then
+  echo ".source.sh not found. This is required in order to go further."
+  exit 1
+fi
+
+# Use this for the first execution. Just to setup the execution time before
+# running the benchmarks.
+if [[ $1 == "--setup_exec_time" ]]; then
+  execution_time=$(date +%F_%H:%M:%S)
+  echo "export EXECUTION_TIME=$execution_time" > ../.source.sh
+  exit 0;
+fi
+
+# If a get-log execution is not already in progress, then create a inprogress
+# file and continue. Otherwise exit
+if [ ! -f ../.get-log-inprogress  ]; then
+  touch ../.get-log-inprogress
+else
+  echo "get-logs.sh is already in progress."
+  echo "If you think that this is an error remove the .get-log-inprogress file"
+  echo "Exiting."
+  exit 1
+fi
+
+
+# Get the timestamp that is in .source.sh
+source ../.source.sh
+mkdir -p "$EXECUTION_TIME"
+cd "$EXECUTION_TIME" || exit
+
+
+hdfs dfs -get /spark_event_logs ./
+
+
+# Count is only used to skip the first iteration of the below for loop. The
+# first iteration has folder = $PWD/spark-perf/results/ which is the folder I
+# was looking in to find useful stuff. So that folder as a result is useless.
+count=0
+for folder in "${result_log_files[@]}"; do
+  # Skip index 0
+  if (( count > 0 )); then
+
+    # Spark-perf result logs
+    # Iterate for every file that is in folder of spark-perf/results
+    # file will end up being something like "<path to file>/glm-regression.err"
+    for file in $folder/*.err; do
+      # Remove the path from the file, so we are just left with the filename
+      filename=$(basename "$file")
+      # Create a folder with that name, but remove the extension of the file
+      mkdir -p "${filename%.*}"
+      cd "${filename%.*}" || exit
+
+      ## Result Logs
+      # Symlink all the .err and .out files for that category if this is not the
+      # last run. Otherwise, delete the symlinks and copy the files over.
+      if [[ $1 == "--last_exec" ]]; then
+        rm -rf "${filename%.*}".err
+        rm -rf "${filename%.*}".out
+        cp $folder/"${filename%.*}".err ./
+        cp $folder/"${filename%.*}".out ./
+      else
+        ln -sf $folder/"${filename%.*}".err
+        ln -sf $folder/"${filename%.*}".out
+      fi
+
+
+      # Search for the app_ids of each category and stick them into a list
+      app_ids=( $(grep -o 'app-[0-9]\{14\}-[0-9]\{4\}' "${filename%.*}".err) )
+
+      ## Executor Logs
+      mkdir -p executor_logs
+      cd executor_logs || exit
+      for app in "${app_ids[@]}"; do
+      # Symlink all the executor logs if this is not the last run. Otherwise,
+      # delete the symlinks and copy the files over.
+      if [[ $1 == "--last_exec" ]]; then
+        rm -rf "$app"
+        cp -r "$EXECUTOR_LOGS/$app" ./
+      else
+        rm -rf "$app"
+        ln -sf "$EXECUTOR_LOGS/$app"
+      fi
+
+      done
+      cd .. || exit
+
+      # Event Logs
+      mkdir -p event_logs
+      cd event_logs || exit
+      # Remove the inprogress files. This way if it turns out that that app_id
+      # is not in progress anymore, the inprogress file will not appear from now
+      # on.
+      rm -rf *.inprogress
+      for app in "${app_ids[@]}"; do
+        # Try both of these locations. Send stdout and stderr to /dev/null
+        # though for the first one, since if it isn't there we probably already
+        # moved it to /mnt/scratch somewhere.
+        mv  ../../spark_event_logs/${app} ./ > /dev/null 2>&1
+        mv  ../../spark_event_logs/${app}.inprogress ./ > /dev/null 2>&1
+      done
+      cd ../.. || exit
+    done
+  fi
+  ((count++))
+done
+
+rm -rf spark_event_logs
+
+cd "$SPARK_PERF_LOGS"/../ || exit
+echo "Logs saved into logs/$EXECUTION_TIME"
+rm -rf .get-log-inprogress

--- a/local-hadoop/source.sh
+++ b/local-hadoop/source.sh
@@ -14,6 +14,8 @@ export HADOOP_YARN_HOME=$HADOOP_PREFIX
 export HADOOP_CONF_DIR=$DIR/../hadoop-config-gen/out
 export YARN_CONF_DIR=$HADOOP_PREFIX/etc/hadoop
 export SPARK_BIN=$DIR/spark
+export SPARK_PERF_LOGS=$DIR/../benchmarks/spark-perf/logs
+export EXECUTOR_LOGS=$DIR/spark/work
 
 #optional java instrumenation
 export JAVA_HOME="/usr/java/jdk1.8.0_77/"


### PR DESCRIPTION
Before Merging this I would like to test it out with a real run of the benchmarks which I will probably run later tonight. So far I have only tried it with the current files we have. This PR is really only to show what I have right now and see if anyone has any concerns with it.

Also currently I have the script checking HDFS and /mnt/scratch for the event logs (since I needed to check the scratch directory to test it because that is where most of the logs are).
#### Description of New Files that are ignored
- source.sh
  - A new file that holds the execution time once "make" is executed. This file holds a variable that is sourced which tells the script what the date and time execution started. I did it this way so that while the benchmarks are running, we can manually run the get-logs.sh script and the script will know where to put the files always. This file is deleted once the "make" target finishes (ie. the benchmarks complete)
- .timestamp_file
  - This file is created right before the benchmarks start up. I use this file as a reference point. Any log file I come across that is newer than this file gets added to our new log folder in the correct timestamp.
#### benchmarks/spark-perf/.gitignore

A local gitignore that just ignores the logs folder where all the logs are moved to, a new local source.sh file, and a new local .timestamp_file file.
#### benchmarks/spark-perf/Makefile

Updated the makefile to call the get-log script and also creates the .timestamp_file file.
#### get-log script

Is the script that gets the logs and does basically everything related to it.
#### local-hadoop/source.sh

added two environment variables. The first one points to the directory that all the logs are stored under, and the second is the location of the executor logs before they are moved. We could add more of these later.
