### PR TITLE
Several Changes to Spark-perf

### DIFF
--- a/benchmarks/spark-perf/README.md
+++ b/benchmarks/spark-perf/README.md
@@ -19,7 +19,7 @@ fetch the logs.
 
 If neither the .source.sh file or .timestamp_file exist then the benchmarks will
 run. If both files exist then this command fetches the logs. If only one of them
-exists then it returns an eror.
+exists then it returns an error.
 
 ```bash
 $ make
@@ -28,7 +28,9 @@ $ make
 #### Changing the Spark Folders
 
 Just change the "spark-bin" variable in the source.sh file in local-hadoop to
-your path and rerun. The script will resource the file for you.
+your path and rerun. The script will resource the file for you. You will also
+need to copy over the spark-defaults.conf file in local-hadoop/spark/conf to
+your custom build.
 
 #### Clean
 

--- a/benchmarks/spark-perf/README.md
+++ b/benchmarks/spark-perf/README.md
@@ -30,6 +30,13 @@ $ make
 Just change the "spark-bin" variable in the source.sh file in local-hadoop to
 your path and rerun. The script will resource the file for you.
 
+#### Clean
+
+In the event that you had to interrupt an execution, run `make clean`. This will
+remove some temporary files that tell the script that an execution is underway.
+While these files are present an execution of `make` will fetch logs instead of
+executing.
+
 ## SSH Setup
 
 The ./bin/run script that is used to run the tests uses ssh. If you do not want

--- a/benchmarks/spark-perf/README.md
+++ b/benchmarks/spark-perf/README.md
@@ -25,6 +25,11 @@ exists then it returns an eror.
 $ make
 ```
 
+#### Changing the Spark Folders
+
+Just change the "spark-bin" variable in the source.sh file in local-hadoop to
+your path and rerun. The script will resource the file for you.
+
 ## SSH Setup
 
 The ./bin/run script that is used to run the tests uses ssh. If you do not want

--- a/benchmarks/spark-perf/get-rdd.sh
+++ b/benchmarks/spark-perf/get-rdd.sh
@@ -22,60 +22,63 @@ if [ -z "$2" ]; then
 
   appid=`expr match "$1" '.*\(app-[0-9]\{14\}-[0-9]\{4\}*\)'`
 
-  hits_file="rdd_hits.txt"
-  misses_file="rdd_misses.txt"
-  evictions_file="rdd_evictions.txt"
-  size_file="rdd_size.txt"
-  computation_file="rdd_computation.txt"
-  hits_ratio_file="rdd_hits_ratio.txt"
-  misses_ratio_file="rdd_misses_ratio.txt"
 
-  destination="../../rdd_hits_and_misses/${appid}"
+  cd ../..
+  destination="$(pwd)/rdd_hits_and_misses/${appid}"
   mkdir -p "$destination"
+  cd -
+
+  hits_file="${destination}/rdd_hits.txt"
+  misses_file="${destination}/rdd_misses.txt"
+  evictions_file="${destination}/rdd_evictions.txt"
+  size_file="${destination}/rdd_size.txt"
+  computation_file="${destination}/rdd_computation.txt"
+  hits_ratio_file="${destination}/rdd_hits_ratio.txt"
+  misses_ratio_file="${destination}/rdd_misses_ratio.txt"
 
 
-  rm -rf "$destination"/"$hits_file"
-  touch "$destination"/"$hits_file"
+  rm -rf "$hits_file"
+  touch "$hits_file"
 
-  rm -rf "$destination"/"$hits_ratio_file"
-  touch "$destination"/"$hits_ratio_file"
+  rm -rf "$hits_ratio_file"
+  touch "$hits_ratio_file"
 
-  rm -rf "$destination"/"$misses_file"
-  touch "$destination"/"$misses_file"
+  rm -rf "$misses_file"
+  touch "$misses_file"
 
-  rm -rf "$destination"/"$misses_ratio_file"
-  touch "$destination"/"$misses_ratio_file"
+  rm -rf "$misses_ratio_file"
+  touch "$misses_ratio_file"
 
-  rm -rf "$destination"/"$evictions_file"
-  touch "$destination"/"$evictions_file"
+  rm -rf "$evictions_file"
+  touch "$evictions_file"
 
-  rm -rf "$destination"/"$size_file"
-  touch "$destination"/"$size_file"
+  rm -rf "$size_file"
+  touch "$size_file"
 
-  rm -rf "$destination"/"$computation_file"
-  touch "$destination"/"$computation_file"
+  rm -rf "$computation_file"
+  touch "$computation_file"
 
   # Combine all app log files into one file called rdd_hits.txt
-  grep 'found block rdd_[0-9]\{1,\}_[0-9]\{1,\}' * -Ri > "$destination"/"$hits_file"
-  grep 'Partition rdd_[0-9]\{1,\}_[0-9]\{1,\} not found, computing it' * -Ri > "$destination"/"$misses_file"
-  grep 'Dropping block' * -Ri > "$destination/$evictions_file"
-  grep 'stored as values in memory' * -Ri | grep 'rdd' > "$destination/$size_file"
-  grep 'computed and cached in' * -Ri > "$destination/$computation_file"
+  grep 'found block rdd_[0-9]\{1,\}_[0-9]\{1,\}' * -Ri > "$hits_file"
+  grep 'Partition rdd_[0-9]\{1,\}_[0-9]\{1,\} not found, computing it' * -Ri > "$misses_file"
+  grep 'Dropping block' * -Ri > "$evictions_file"
+  grep 'stored as values in memory' * -Ri | grep 'rdd' > "$size_file"
+  grep 'computed and cached in' * -Ri > "$computation_file"
 
   # Delete everything from beginning of line to first occurrence of "rdd"
-  sed -i 's/^.*rdd/rdd/p' "$destination"/"$hits_file"
-  sed -i 's/^.*rdd/rdd/p' "$destination"/"$misses_file"
-  sed -i 's/^.*rdd/rdd/p' "$destination"/"$evictions_file"
-  sed -i 's/^.*rdd/rdd/p' "$destination"/"$size_file"
-  sed -i 's/^.*rdd/rdd/p' "$destination"/"$computation_file"
+  sed -i 's/^.*rdd/rdd/p' "$hits_file"
+  sed -i 's/^.*rdd/rdd/p' "$misses_file"
+  sed -i 's/^.*rdd/rdd/p' "$evictions_file"
+  sed -i 's/^.*rdd/rdd/p' "$size_file"
+  sed -i 's/^.*rdd/rdd/p' "$computation_file"
 
   # Delete from the end of the rdd tag (denoted by a space) to the eol
-  sed -i "s@ .*@@g" "$destination"/"$hits_file"
-  sed -i "s@ .*@@g" "$destination"/"$misses_file"
-  sed -i "s@ .*@@g" "$destination"/"$evictions_file"
-  sed -i "s@ .*estimated size@  @g" "$destination"/"$size_file"
-  sed -i "s@, .*@@g" "$destination"/"$size_file"
-  sed -i "s@ .*computed and cached in@@g" "$destination"/"$computation_file"
+  sed -i "s@ .*@@g" "$hits_file"
+  sed -i "s@ .*@@g" "$misses_file"
+  sed -i "s@ .*@@g" "$evictions_file"
+  sed -i "s@ .*estimated size@  @g" "$size_file"
+  sed -i "s@, .*@@g" "$size_file"
+  sed -i "s@ .*computed and cached in@@g" "$computation_file"
 
 
 else
@@ -209,7 +212,7 @@ exec 0<&10 10<&-
 rm -rf master
 rm -rf master_ratio
 
-rm -rf rdd_hits_ratio.txt
+rm -rf $hits_ratio_file
 rm -rf rdd_misses_ratio.txt
 
 for((i=0;i<id_count;i++)); do
@@ -218,7 +221,7 @@ for((i=0;i<id_count;i++)); do
   miss_rate=$(echo "scale=3; ($misses*100 / $total)" | bc -l)
   hit_rate=$(echo "(100 - $miss_rate)" | bc -l)
 
-  echo "$hit_rate rdd_${master_id[$i]}_${master_blockid[$i]}" >> rdd_hits_ratio.txt
+  echo "$hit_rate rdd_${master_id[$i]}_${master_blockid[$i]}" >> $hits_ratio_file
   echo "$miss_rate rdd_${master_id[$i]}_${master_blockid[$i]}" >> rdd_misses_ratio.txt
 done
 

--- a/benchmarks/spark-perf/get-rdd.sh
+++ b/benchmarks/spark-perf/get-rdd.sh
@@ -26,6 +26,7 @@ if [ -z "$2" ]; then
   misses_file="rdd_misses.txt"
   evictions_file="rdd_evictions.txt"
   size_file="rdd_size.txt"
+  computation_file="rdd_computation.txt"
   hits_ratio_file="rdd_hits_ratio.txt"
   misses_ratio_file="rdd_misses_ratio.txt"
 
@@ -51,17 +52,22 @@ if [ -z "$2" ]; then
   rm -rf "$destination"/"$size_file"
   touch "$destination"/"$size_file"
 
+  rm -rf "$destination"/"$computation_file"
+  touch "$destination"/"$computation_file"
+
   # Combine all app log files into one file called rdd_hits.txt
   grep 'found block rdd_[0-9]\{1,\}_[0-9]\{1,\}' * -Ri > "$destination"/"$hits_file"
   grep 'Partition rdd_[0-9]\{1,\}_[0-9]\{1,\} not found, computing it' * -Ri > "$destination"/"$misses_file"
   grep 'Dropping block' * -Ri > "$destination/$evictions_file"
   grep 'stored as values in memory' * -Ri | grep 'rdd' > "$destination/$size_file"
+  grep 'computed and cached in' * -Ri > "$destination/$computation_file"
 
   # Delete everything from beginning of line to first occurrence of "rdd"
   sed -i 's/^.*rdd/rdd/p' "$destination"/"$hits_file"
   sed -i 's/^.*rdd/rdd/p' "$destination"/"$misses_file"
   sed -i 's/^.*rdd/rdd/p' "$destination"/"$evictions_file"
   sed -i 's/^.*rdd/rdd/p' "$destination"/"$size_file"
+  sed -i 's/^.*rdd/rdd/p' "$destination"/"$computation_file"
 
   # Delete from the end of the rdd tag (denoted by a space) to the eol
   sed -i "s@ .*@@g" "$destination"/"$hits_file"
@@ -69,6 +75,7 @@ if [ -z "$2" ]; then
   sed -i "s@ .*@@g" "$destination"/"$evictions_file"
   sed -i "s@ .*estimated size@  @g" "$destination"/"$size_file"
   sed -i "s@, .*@@g" "$destination"/"$size_file"
+  sed -i "s@ .*computed and cached in@@g" "$destination"/"$computation_file"
 
 
 else
@@ -90,6 +97,8 @@ sort -bnr "$misses_file" > tmp && mv tmp "$misses_file"
 
 sort "$evictions_file" | uniq -c > tmp && mv tmp "$evictions_file"
 sort -bnr "$evictions_file" > tmp && mv tmp "$evictions_file"
+
+sort -bnr "$computation_file" > tmp && mv tmp "$computation_file"
 
 sort master | uniq -c > tmp && mv tmp master
 sort -bnr master > tmp && mv tmp master

--- a/benchmarks/spark-perf/run-script.sh
+++ b/benchmarks/spark-perf/run-script.sh
@@ -37,6 +37,7 @@ function default_config {
 # run {{{
 function run {
   cd spark-perf
+  cp config/config.py ../logs/$EXECUTION_TIME/config.py
   ./bin/run > >(tee ../logs/$EXECUTION_TIME/sparkperf-output.out) 2> >(tee ../logs/$EXECUTION_TIME/sparkperf-output.err >&2)
 }
 

--- a/benchmarks/spark-perf/run-script.sh
+++ b/benchmarks/spark-perf/run-script.sh
@@ -2,6 +2,8 @@
 
 CONFIG_PATH=./spark-perf/config
 source .source.sh
+source ../../local-hadoop/source.sh
+
 
 #local_config {{{
 function local_config {

--- a/local-hadoop/source.sh
+++ b/local-hadoop/source.sh
@@ -15,7 +15,7 @@ export HADOOP_CONF_DIR=$DIR/../hadoop-config-gen/out
 export YARN_CONF_DIR=$HADOOP_PREFIX/etc/hadoop
 export SPARK_BIN=$DIR/spark
 export SPARK_PERF_LOGS=$DIR/../benchmarks/spark-perf/logs
-export EXECUTOR_LOGS=$DIR/spark/work
+export EXECUTOR_LOGS=$SPARK_BIN/work
 
 #optional java instrumenation
 export JAVA_HOME="/usr/java/jdk1.8.0_77/"

--- a/local-hadoop/source.sh
+++ b/local-hadoop/source.sh
@@ -13,7 +13,8 @@ export HADOOP_YARN_HOME=$HADOOP_PREFIX
 #export HADOOP_CONF_DIR=~/docker-volumes/hadoop-config/
 export HADOOP_CONF_DIR=$DIR/../hadoop-config-gen/out
 export YARN_CONF_DIR=$HADOOP_PREFIX/etc/hadoop
-export SPARK_BIN=$DIR/spark
+# export SPARK_BIN=$DIR/spark
+export SPARK_BIN=~/Documents/custom-spark/spark-1.6.3-SNAPSHOT-bin-craig-extralogs
 export SPARK_PERF_LOGS=$DIR/../benchmarks/spark-perf/logs
 export EXECUTOR_LOGS=$SPARK_BIN/work
 


### PR DESCRIPTION
Includes:
- Script Additions to find the computation times
- sourcing of the local-hadoop/source.sh file to make sure it is sourced
- Changed the local-hadoop/source.sh file to have an executor log location that is dependent on spark-bin
- Spark-perf run script now also saves the spark-perf configuration that was used to run it in the logs folder to look back on
- Full path is used for the file variables in get-logs script
- Added instructions to the spark-perf readme explaining what to do in order to use spark-perf specified build of spark.
